### PR TITLE
Errores en el estilo del planet

### DIFF
--- a/planet/custom/style/planet_mh.css
+++ b/planet/custom/style/planet_mh.css
@@ -1,3 +1,17 @@
+/* Estructura  */
+.planet .portada-individual {
+	float: none;
+	width: auto;
+}
+
+
+/* Tipografía */
+.planet .dia-publicacion {
+	margin: 0 0 2em 0;
+	float: none;
+}
+
+
 /* Fotos de los artículos */
 .portada-individual .texto-portada-individual img {
         max-width: 100%;

--- a/planet/custom/views/default/index.tpl.php
+++ b/planet/custom/views/default/index.tpl.php
@@ -1,6 +1,6 @@
 <?php
 	ini_set('display_errors', "1");
-	ini_set('error_reporting', E_ALL ^ E_NOTICE);
+	ini_set('error_reporting', E_ALL ^ E_NOTICE); 
 	$limit = $PlanetConfig->getMaxDisplay();
 	$count = 0;
 	header('Content-type: text/html; charset=UTF-8');
@@ -25,7 +25,7 @@
 	<div id="tullido">
 		<?php include(dirname(__FILE__).'/top.tpl.php'); ?>
 		<div id="cuerpo" class="clearfix">
-		    <div id="contenido">
+		    <div id="contenido" class="planet">
 				<div id="main-content">
 					<div id="texto-bienvenida">
 						<p>Bienvenido a Planet Mozilla Hispano, en esta sección se listan los últimos artículos en los blogs, twitts y fotos de los miembros y colaboradores de la comunidad de Mozilla en español. Mozilla Hispano no es responsable de las opiniones de los autores en sus blogs personales.</p>


### PR DESCRIPTION
Solucionado problema del ancho de cada articulo y espaciado del parrafo con los datos del autor y fecha.

Aparentemente hay lineas modificadas por cambios en el modo de los finales de lineas. Si hace falta volver atrás con esto por favor avisar.
