### PR TITLE
Rss de labs y enlace a descargas II

### DIFF
--- a/wp-content/themes/mozillahispano2/labs-index.php
+++ b/wp-content/themes/mozillahispano2/labs-index.php
@@ -60,7 +60,7 @@ get_header(); ?>
 		</div>
 		
 		<div id="ultimas-noticias">
-                    <h2><a href="http://www.mozilla-hispano.org/etiqueta/labs/feed/"><img src="/wp-content/themes/mozillahispano2/img/feed.png" alt="feed" /></a> Artículos</h2>
+                    <h2><a href="http://www.mozilla-hispano.org/etiqueta/labs/feed/"><img src="/wp-content/themes/mozillahispano/img/rss.png" alt="feed" /></a> Artículos</h2>
 			<?php 
 				query_posts('tag=labs&posts_per_page=5');
 				if (have_posts()) : ?>
@@ -96,7 +96,7 @@ get_header(); ?>
 
 				<?php endwhile; ?>
 				
-				<p id="labs-more"><a href="/etiqueta/labs/">Ver todos los artículos</a></p>
+				<p id="labs-more"><a href="/etiqueta/desarrollo/">Ver todos los artículos</a></p>
 			<?php endif; ?>
 
 		</div>

--- a/wp-content/themes/mozillahispano2/sidebar.php
+++ b/wp-content/themes/mozillahispano2/sidebar.php
@@ -79,7 +79,9 @@
                <!-- Descargas -->
 		
 		<h3 id="descargas">Descargas</h3>
-                <a href="/productos">Descarga</a> los programas de mozilla.        
+                <p class="boletin">
+                    <a href="/productos">Descarga</a> los programas de mozilla.
+                </p>       
 			
 		<!-- Artículos destacados -->
 		


### PR DESCRIPTION
La imagen del enlace a los rss de labs no se veía porque estaba mal puesta la dirección. El texto del enlace a descargas no tenía margen. 
