### PR TITLE
Ejemplo de uso de desde php de la las partes comunes del sitio cabecera,...

### DIFF
--- a/html-responsive/test-bloques-pinta.php
+++ b/html-responsive/test-bloques-pinta.php
@@ -1,0 +1,28 @@
+<?php
+require ('../wp-content/themes/mozillahispano2/cabecera-pie.php');
+$cabecera = pintaCabecera();
+$pie = pintaPie();
+$js = pintaJs();
+$css = pintaCss();
+
+?><!doctype html>
+<html lang="es" dir="ltr">
+<head>
+	<meta charset="utf-8"/>
+	<?=$css?>
+</head>
+<body>
+	<div id="lienzo">
+		<div id="tullido">
+			<a href="http://www.mozilla.org" id="tabzilla">Mozilla</a><!-- quitar cuando se meta en cabecera -->
+			<?=$cabecera?>
+			<div id="cuerpo">
+				<div id="contenido">Contenido</div>
+				<div id="barra">Barra</div>
+			</div>
+		</div>
+		<?=$pie?>
+	</div>
+	<?=$js?>
+</body>
+</html>


### PR DESCRIPTION
... pie, css y js

Se trata de un ejemplo con los bloques pre-responsive y la maqueta no será así ya que por ejemplo tabzilla irá dentro de la cabecera. Sirve de ejemplo para ilustrar como de deben manejar.
