### PR TITLE
[issue #37] Soluciona que no se muestre el reCaptcha en Chrome y FF 23

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -3,7 +3,7 @@ SetEnv PHP_VER 5
 SetEnv REGISTER_GLOBALS 0
 SetEnv ZEND_OPTIMIZER 1
 SetEnv MAGIC_QUOTES 0
-SetEnvIf Request_URI "^/documentacion/" HTTPS=on
+SetEnvIf Request_URI "^/(documentacion|foro)/" HTTPS=on
 <IfModule mod_rewrite.c>
 RewriteEngine on
 RewriteBase /


### PR DESCRIPTION
Con este cambio solo se deberia colocar la variable HTTPS=on cuando se entre
a la documentacion.
