### PR TITLE
#105: El botón de "Buscar" del sidebar de portada salta de línea

### DIFF
--- a/wp-content/themes/mozillahispano2/style.css
+++ b/wp-content/themes/mozillahispano2/style.css
@@ -16,7 +16,8 @@ video {
 }
 
 #searchform input[type='text'] {
-	width: 170px;
+	width: 160px;
+	height: 25px;
 }
 
 #contenido #main-content {


### PR DESCRIPTION
Aline el botón de buscar a la derecha del input, al cual le marca una altura de 25px. Quicfix que más adelante se modificará con el responsive.
