### PR TITLE
FIX #133 - Agrega media querie para sidebar

### DIFF
--- a/wp-content/themes/mozillahispano2/css/responsive.css
+++ b/wp-content/themes/mozillahispano2/css/responsive.css
@@ -23,6 +23,14 @@
   }
 }
 
+@media screen and (max-width: 880px) {
+
+  #contenido h3 {
+    font-size: 1.6em;
+  }
+
+}
+
 @media screen and (min-width: 795px) {
   #page-body {
     width: 75%;
@@ -32,10 +40,8 @@
     width: 15%;
   }
 
-  #contenido h3 {
-	  font-size: 1.05em;
-  }
 }
+
 
 @media screen and (max-width: 330px) {
   #tullido {
@@ -48,6 +54,10 @@
 
   #main-content {
     width: auto !important;
+  }
+
+  #contenido h3 {
+    font-size: 1.05em;
   }
 
   /*#lienzo, #tullido {


### PR DESCRIPTION
Mueve la query dentro de otra, ya que a los 880px se puede colocar el texto "Boletín Firefox" sin que se rompa.

Así quedaría en 768:
![Sidebar](http://f.cl.ly/items/3B2C1Y1J2L3Q3t0b2L2C/responsive-768.png)
