### PR TITLE
Borra CSS específico de Fancybox que rompe imágenes en WP

### DIFF
--- a/wp-content/themes/mozillahispano2/style.css
+++ b/wp-content/themes/mozillahispano2/style.css
@@ -673,11 +673,6 @@ Author URI: http://dev7studios.com
     width: 100% !important;
 }
 
-a.fancybox img.size-full, img.size-medium {
-	float: left;
-    margin: 0 20px 12px 0;
-}
-
 .portada-individual, .portada-extra{
 	border-bottom: 1px solid #E5E5E5 !important;
     margin: 1em !important;


### PR DESCRIPTION
FIXES #125: Css de Fancybox rompe imágenes en WP
