### PR TITLE
Agrega z-index al menú reponsive para evitar ser tapado

### DIFF
--- a/wp-content/themes/mozillahispano2/css/responsive.css
+++ b/wp-content/themes/mozillahispano2/css/responsive.css
@@ -490,10 +490,11 @@ ul.topiclist dt {
   }
 
   #menu {
-    font-size: 12px;
+    position: absolute;
     padding-top: 20px;
     display: block;
-    position: absolute;
+    z-index: 999999;
+    font-size: 12px;
  }
 
   #menu .clearfix {


### PR DESCRIPTION
Fix #167: El carrousel tapa el menú responsive
