### PR TITLE
Unificar cabecera_pie a falta del meta viewport

### DIFF
--- a/foro/includes/cabecera-pie.php
+++ b/foro/includes/cabecera-pie.php
@@ -4,35 +4,64 @@ function pintaCabecera()
 $temp= <<<PINTA
 <div id="cabecera">
 				<div id="alojaLogo">
-
 					<h1><a href="/">Mozilla hispano, tu comunidad en español de Mozilla</a></h1>
 				</div>
 				<div id="menu">
 					<span id="toggle"></span>
 					<ul id="menu-nav" class="clearfix">
-							<li><a href="/">Noticias</a></li>
-							<li><a href="/foro/">Foro</a>
-								<ul class="submenu">
-									<li><a href="/foro/viewforum.php?f=1" title="Foro de asistencia técnica">Foro de asistencia</a></li>
-									<li><a href="/documentacion/" title="Documentos, artículos y preguntas frecuentes de ayuda a los usuarios">Documentación</a></li>
-								</ul>
-							</li>
-							<li><a href="/difusion/" title="Ayuda a difundir Mozilla en español">Difusión</a>
-								<ul class="submenu">
-									<li><a href="/documentacion/Eventos" title="Eventos Mozilla">Eventos</a></li>
-									<li><a href="/documentacion/Difusi%C3%B3n" title="Proyectos de difusión">Proyectos</a></li>
-								</ul>
-							</li>
-							<li><a href="/podcast/">Podcast</a></li>
-							<li><a href="/labs/" title="Centro de desarrollo e innovación en la plataforma Mozilla">Labs</a></li>
-							<li><a href="/planet/" title="Artículos de opinión, mensajes y fotos de los miembros de la comunidad">Planet</a></li>
-							<li><a href="/documentacion/Colabora" title="Únete y colabora con Mozilla Hispano">Únete</a>
-								<ul class="submenu">
-										<li><a href="/documentacion/Programa_de_mentores" title="Programa de mentores">Programa de mentores</a></li>
-										<li><a href="/documentacion/Recursos_para_colaboradores" title="Recursos para colaboradores">Recursos para colaboradores</a></li>
-										<li><a href="/documentacion/Colaboradores" title="Listado de colaboradores">Colaboradores</a></li>
-								</ul>
-							</li>
+						<li><a href="/">Noticias</a></li>
+						<li><span>Asistencia</span>
+							<ul class="submenu">
+								<li><a href="/foro/" title="Foro de asistencia técnica">Foro de asistencia</a></li>
+								<li><a href="/documentacion/" title="Documentos, artículos y preguntas frecuentes de ayuda a los usuarios">Documentación</a></li>
+								<li><a href="/documentacion/Asistencia" title="Proyectos">Proyectos</a></li>
+							</ul>
+						</li>
+						<li><span title="Ayuda a difundir Mozilla en español">Difusión</span>
+							<ul class="submenu">
+								<li><a href="/difusion/">Promociona Mozilla</a></li>
+								<li><a href="/foro/viewforum.php?f=6" title="Foro de difusión">Foros</a></li>
+								<li><a href="/documentacion/Eventos" title="Eventos Mozilla">Eventos</a></li>
+								<li><a href="/documentacion/Difusi%C3%B3n" title="Proyectos de difusión">Proyectos</a></li>
+							</ul>
+						</li>
+						<li><a href="/podcast/">Podcast</a></li>
+						<li><span title="Desarrolla con Labs">Labs</span>
+							<ul class="submenu">
+								<li><a href="/labs/" title="Centro de desarrollo e innovación en la plataforma Mozilla">Blog y proyectos</a></li>
+								<li><a href="/foro/viewforum.php?f=25">Foros</a></li>
+							</ul>
+						</li>
+						<li><span>Comunidad</span>
+							<ul class="submenu">
+								<li><a href="/planet/" title="Artículos de opinión, mensajes y fotos de los miembros de la comunidad">Planet</a></li>
+								<li><a href="/documentacion/Colaboradores" title="Listado de colaboradores">Colaboradores</a></li>
+								<li><a href="/ar/">Argentina</a></li>
+								<li><a href="/bo/">Bolivia</a></li>
+								<li><a href="/co/">Colombia</a></li>
+								<li><a href="/cr/">Costa Rica</a></li>
+								<li><a href="/cl/">Chile</a></li>
+								<li><a href="/cu/">Cuba</a></li>
+								<li><a href="/es/">España</a></li>
+								<li><a href="/ec/">Ecuador</a></li>
+								<li><a href="/ni/">Nicaragua</a></li>
+								<li><a href="/mx/">México</a></li>
+								<li><a href="/py/">Paraguay</a></li>
+								<li><a href="/pe/">Perú</a></li>
+								<li><a href="/uy/">Uruguay</a></li>
+								<li><a href="/ve/">Venezuela</a></li>
+							</ul>
+						</li>
+						<li><span title="Únete y colabora con Mozilla Hispano">Participa</span>
+							<ul class="submenu">
+								<li><a href="/documentacion/Colabora">Cómo participar</a></li>
+								<li><a href="/documentacion/Recursos_para_colaboradores" title="Recursos para colaboradores">Recursos para colaboradores</a></li>
+								<li><a href="/foro/viewforum.php?f=6">Foros</a></li>
+								<li><a href="/documentacion/Proyectos">Proyectos</a></li>
+								<li><a href="/documentacion/Tareas">Tareas</a></li>
+								<li><a href="/documentacion/Reuniones">Reuniones</a></li>
+							</ul>
+						</li>
 					</ul>
 				</div>
 				<div id="social">
@@ -99,29 +128,36 @@ $temp= <<<PINTA
 				<li><a href="/documentacion/Asistencia">Asistencia</a></li>
 				<li><a href="/documentacion/Noticias">Noticias</a></li>
 				<li><a href="/documentacion/Localizaci%C3%B3n">Localización</a></li>
-				<li><a href="/documentacion/Labs">Labs</a></li>
-				<li><a href="/documentacion/Control_de_calidad">Control de calidad</a></li>
+                <li><a href="/documentacion/Labs">Labs</a></li>
+                <li><a href="/documentacion/Control_de_calidad">Control de calidad</a></li>
 				<li><a href="/documentacion/Administraci%C3%B3n_t%C3%A9cnica">Adm. Técnica</a></li>
 			</ul>
 		</div>
 	</div>
 </div>
 
-<script type='text/javascript' src='https://www.mozilla.org/tabzilla/media/js/tabzilla.js'></script>
+<script type="text/javascript" src="//mozorg.cdn.mozilla.net/tabzilla/tabzilla.js"></script>
 <script type='text/javascript'>var tab=document.createElement('a');tab.href="https://www.mozilla.org/";tab.id="tabzilla";
 tab.innerHTML="mozilla";var tullido=document.getElementById('tullido');tullido.insertBefore(tab,tullido.firstChild);</script>
 
+<!-- Piwik -->
 <script type="text/javascript">
-var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
-document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
+  var _paq = _paq || [];
+  _paq.push(["setDomains", ["*.www.mozilla-hispano.org"]]);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u=(("https:" == document.location.protocol) ? "https" : "http") + "://stats.mozilla-hispano.org/";
+    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    _paq.push(['setSiteId', 1]);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript';
+    g.defer=true; g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+  })();
 </script>
+<noscript><p><img src="//stats.mozilla-hispano.org/piwik.php?idsite=1" style="border:0;" alt="" /></p></noscript>
+<!-- End Piwik Code -->
 
-<script type="text/javascript">
-var pageTracker = _gat._getTracker("UA-2846159-1");
-pageTracker._initData();
-pageTracker._trackPageview();
-</script>
-
+<script type="application/x-javascript" src="/wp-content/themes/mozillahispano2/js/labs_functions.js" ></script>
 <script type="text/javascript" src="/wp-content/themes/mozillahispano2/js/menu.js"></script>
 <script type="text/javascript" src="/wp-content/themes/mozillahispano2/js/responsive.js"></script>
 <script type="text/javascript" src="/wp-content/themes/mozillahispano2/js/jquery.cookiebar.js"></script>
@@ -131,6 +167,7 @@ pageTracker._trackPageview();
 	});
 </script>
 
+
 PINTA;
 return $temp;
 }
@@ -138,7 +175,7 @@ return $temp;
 function pintaCss()
 {
 $temp= <<<PINTA
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
 
 	<link type="image/x-icon" href="/favicon.ico" rel="shortcut icon" />
 

--- a/wp-content/themes/mozillahispano2/cabecera-pie.php
+++ b/wp-content/themes/mozillahispano2/cabecera-pie.php
@@ -7,7 +7,7 @@ $temp= <<<PINTA
 					<h1><a href="/">Mozilla hispano, tu comunidad en español de Mozilla</a></h1>
 				</div>
 				<div id="menu">
-          <span id="toggle"></span>
+					<span id="toggle"></span>
 					<ul id="menu-nav" class="clearfix">
 						<li><a href="/">Noticias</a></li>
 						<li><span>Asistencia</span>
@@ -26,12 +26,12 @@ $temp= <<<PINTA
 							</ul>
 						</li>
 						<li><a href="/podcast/">Podcast</a></li>
-                        <li><span title="Desarrolla con Labs">Labs</span>
-                            <ul class="submenu">
-                                <li><a href="/labs/" title="Centro de desarrollo e innovación en la plataforma Mozilla">Blog y proyectos</a></li>
-                                <li><a href="/foro/viewforum.php?f=25">Foros</a></li>
-                            </ul>
-                        </li>
+						<li><span title="Desarrolla con Labs">Labs</span>
+							<ul class="submenu">
+								<li><a href="/labs/" title="Centro de desarrollo e innovación en la plataforma Mozilla">Blog y proyectos</a></li>
+								<li><a href="/foro/viewforum.php?f=25">Foros</a></li>
+							</ul>
+						</li>
 						<li><span>Comunidad</span>
 							<ul class="submenu">
 								<li><a href="/planet/" title="Artículos de opinión, mensajes y fotos de los miembros de la comunidad">Planet</a></li>
@@ -55,15 +55,15 @@ $temp= <<<PINTA
 						<li><span title="Únete y colabora con Mozilla Hispano">Participa</span>
 							<ul class="submenu">
 								<li><a href="/documentacion/Colabora">Cómo participar</a></li>
-                                                                <li><a href="/documentacion/Recursos_para_colaboradores" title="Recursos para colaboradores">Recursos para colaboradores</a></li>
-                                                                <li><a href="/foro/viewforum.php?f=6">Foros</a></li>
-                                                                <li><a href="/documentacion/Proyectos">Proyectos</a></li>
-                                                                <li><a href="/documentacion/Tareas">Tareas</a></li>
-                                                                <li><a href="/documentacion/Reuniones">Reuniones</a></li>
+								<li><a href="/documentacion/Recursos_para_colaboradores" title="Recursos para colaboradores">Recursos para colaboradores</a></li>
+								<li><a href="/foro/viewforum.php?f=6">Foros</a></li>
+								<li><a href="/documentacion/Proyectos">Proyectos</a></li>
+								<li><a href="/documentacion/Tareas">Tareas</a></li>
+								<li><a href="/documentacion/Reuniones">Reuniones</a></li>
 							</ul>
 						</li>
 					</ul>
-                                </div>
+				</div>
 				<div id="social">
 					<ul>
 						<li><a title="Síguenos en Twitter" id="twitter-icon" href="http://twitter.com/mozilla_hispano">Síguenos en Twitter</a></li>
@@ -157,8 +157,6 @@ tab.innerHTML="mozilla";var tullido=document.getElementById('tullido');tullido.i
 <noscript><p><img src="//stats.mozilla-hispano.org/piwik.php?idsite=1" style="border:0;" alt="" /></p></noscript>
 <!-- End Piwik Code -->
 
-<!-- Estilos responsive compartidos -->
-<link rel="stylesheet" href="/wp-content/themes/mozillahispano2/css/responsive.css" type="text/css" />
 <script type="application/x-javascript" src="/wp-content/themes/mozillahispano2/js/labs_functions.js" ></script>
 <script type="text/javascript" src="/wp-content/themes/mozillahispano2/js/menu.js"></script>
 <script type="text/javascript" src="/wp-content/themes/mozillahispano2/js/responsive.js"></script>
@@ -181,7 +179,7 @@ $temp= <<<PINTA
 
 	<link rel="alternate" type="application/rss+xml" title="Noticias de Mozilla Hispano" href="http://feeds.mozilla-hispano.org/mozillahispano" />
 	<link rel="alternate" type="application/rss+xml" title="Artículos en Planet Mozilla Hispano" href="http://feeds.mozilla-hispano.org/mozillahispano-planet" />
-    	<link rel="alternate" type="application/rss+xml" title="El Podcast de Mozilla Hispano" href="http://feeds.mozilla-hispano.org/mozillahispano-podcast" />
+	<link rel="alternate" type="application/rss+xml" title="El Podcast de Mozilla Hispano" href="http://feeds.mozilla-hispano.org/mozillahispano-podcast" />
 
 	<link rel="search" type="application/opensearchdescription+xml" title="Mozilla Hispano - Noticias" href="/archivos/noticias.xml" />
 	<link rel="search" type="application/opensearchdescription+xml" title="Mozilla Hispano - Foro" href="/archivos/foro.xml" />
@@ -189,6 +187,7 @@ $temp= <<<PINTA
 
 	<link type="text/css" rel="stylesheet" href="//mozorg.cdn.mozilla.net/media/css/tabzilla-min.css" />
 	<link rel="stylesheet" href="/wp-content/themes/mozillahispano2/css/comun.css" type="text/css" />
+	<link rel="stylesheet" href="/wp-content/themes/mozillahispano2/css/responsive.css" type="text/css" />
 
 PINTA;
 return $temp;
@@ -259,4 +258,3 @@ function mozeuChooseRightLocale_old($product){
 echo $link;
 } // end mozeuChooseRightLocale
 
-?>


### PR DESCRIPTION
En una primera aproximación incluyo en el cabecera_pie del foro todo lo que se ha ido añadiendo en el de WordPress.
Pendiente el revisar en WP quién está añadiendo el meta view-port para hacerlo de la misma manera en el foro y poder volvel a tener el mismo archivo en ambos entornos.
