### PR TITLE
El margen derecho se pierde en resoluciones pequeñas

### DIFF
--- a/wp-content/themes/mozillahispano2/css/responsive.css
+++ b/wp-content/themes/mozillahispano2/css/responsive.css
@@ -84,6 +84,10 @@
     width: 92%;
     margin: 1em !important;
   }
+  #contenido .portada-individual img {
+    width: 100%;
+    height: auto;
+  }
 
   /* Carousel de portada */
   .custom-slider .orbit-wrapper .orbit-caption {


### PR DESCRIPTION
Mejor solución al margen derecho, las imágenes son las que empujan a tener un layout más ancho que la pantalla del móvil