### PR TITLE
Quita un padding !important de .portada-individual

### DIFF
--- a/wp-content/themes/mozillahispano2/style.css
+++ b/wp-content/themes/mozillahispano2/style.css
@@ -682,7 +682,6 @@ Author URI: http://dev7studios.com
 .portada-individual, .portada-extra{
     border-bottom: 1px solid #E5E5E5 !important;
     margin: 1em !important;
-    padding: 1em 1em 2em 1em !important;
     float:left;
     width:70%;
 }


### PR DESCRIPTION
Este padding está rompiendo secciones como la de /advocacy. No encuentro la razón por la que se añadió y por la cual estaba usando un important. No parece romper nada, además de que otras secciones tienen su propia clase que aplica otro padding.